### PR TITLE
Quick implementation of sym (+ tests (dogfooding)).

### DIFF
--- a/emulisp_core.js
+++ b/emulisp_core.js
@@ -963,6 +963,10 @@ var coreFunctions = {
 		if (cv === NIL) return NIL;
 		throw new Error(newErrMsg(CELL_EXP, cv));
 	},
+    "sym": function(c) {
+        if (c.car === NIL) return newTransSymbol("NIL");
+        else return newTransSymbol(evalArgs(c).toString().slice(1, -1));
+    },
 	"tail": function(c) {
 		var cl = evalLisp(c.car), lst = evalLisp(c.cdr.car);
 		if (cl instanceof Cell) {

--- a/emulisp_tests.l
+++ b/emulisp_tests.l
@@ -3,7 +3,7 @@
 		'((BoolExpr)
 			(if (eval BoolExpr)
 				(inc 'Goods)
-				(inc 'Bads) (js:alert BoolExpr (eval (caddr BoolExpr))) ) )
+				(inc 'Bads) (println (pack "Return value for " (sym BoolExpr) " was " (sym (eval (caddr BoolExpr))) ".")) ) )
 		(list
 			'(= '(NIL) (list))
 			'(= T (= "abc" "abc"))
@@ -115,5 +115,12 @@
 			# curiosities
 			'(= 33 ('(22 33)))
 			'(= NIL ('(22)))
+
+			# sym
+			'(= "NIL" (sym NIL))
+			'(= "(1 2 3)" (sym (1 2 3)))
+			'(= "(1 2 3)" (sym '(1 2 3)))
+			'(= "(1 2 3)" (sym (quote 1 2 3)))
+			'(= "\"hello\"" (sym "hello"))
 			) )
 	(println (pack "Tests: " (+ Goods Bads) ", Errors: " Bads)) )


### PR DESCRIPTION
The motivation for implementing this was the test report.

In case of a test not passing, js:alert should not be used IMHO. So I tried to use (println) with a meaningful message (function tested, expected value (the `BoolExpr`) and the actual value) using (sym).

Moreover, I guess that there is a cleaner way to `slice(-1, 1)`.
Jon, since you know the internals better than me, I'd like a hint!
