### PR TITLE
Remove last new line of a print with console.log.

### DIFF
--- a/emulisp_core.js
+++ b/emulisp_core.js
@@ -1183,7 +1183,7 @@ function _stdPrint(text) {
 	if (typeof stdPrint === "function") stdPrint(text)
 	else // when function stdPrint is not available in front end
 	//if (!confirm("_stdPrint:\n" + text)) throw new Error("_stdPrint aborted");
-	console.log(text);
+	console.log(text.replace(/\n$/g,''));  // last new line offered by console.log
 }
 
 function _warn(msg) {


### PR DESCRIPTION
We have (at least with NodeJS) an annoying new line when using (println).
This is because console.log already offers a new line.