### PR TITLE
Fix (get '(+ 2 2) 'text) bug.

### DIFF
--- a/emulisp_core.js
+++ b/emulisp_core.js
@@ -371,6 +371,8 @@ function getAlg(c) {
 				} else {
 					do { s = s.cdr; } while ((s !== NIL) && (++k < 0));
 				}
+			} else {
+				return NIL;
 			}
 		} else throw new Error(newErrMsg(SYM_EXP));
 		c = c.cdr;


### PR DESCRIPTION
Try:

```
$ pil
: (get '(+ 2 2) 'text)
-> NIL
: (bye)
```

But:

```
$ emulisp/piljs
: (get '(+ 2 2) 'text)
-> (+ 2 2)
: (bye)
```

Not sure it was the good way to fix this. I just voodoo'ed it.
Also maybe we could add a test like `'(= NIL (get '(+ 2 2) 'text))`. But where exactly?
