### PR TITLE
Fix pack empty string bug.

### DIFF
--- a/emulisp_core.js
+++ b/emulisp_core.js
@@ -96,6 +96,7 @@ function Symbol(name, val) {
 }
 
 function newTransSymbol(name) {
+	if (name === "") return NIL;
 	var ts = new Symbol(name);
 	ts.trans = true;
 	ts.cdr = ts;

--- a/emulisp_tests.l
+++ b/emulisp_tests.l
@@ -26,6 +26,7 @@
 			'(= 0 (prog (zero N) (= 1 2 (inc 'N)) N))
 			'(= 0 (prog (zero N) (== 1 2 (inc 'N)) N))
 			'(= "1two3T9" (pack 1 "two" (3 T) NIL (+ 4 5)))
+			'(= NIL (pack ""))
 			'(= 6 (eval (list '+ 1 2 3)))
 			'(= "BCDC" (prog (setq A 'B B 'C C 'D) (pack A B C (eval A))))
 			#'(= "BCDC" (let ("A" "B" "B" "C" "C" "D") (pack "A" "B" "C" (eval "A"))))


### PR DESCRIPTION
```
$ pil
: (pack "")
-> NIL
```

but

```
$ piljs
: (pack "")
-> ""
```
