### PR TITLE
Fix @ bug in eval.

### DIFF
--- a/emulisp_core.js
+++ b/emulisp_core.js
@@ -1320,9 +1320,9 @@ var pub = {
 	NIL: NIL, T: T,
 	
 	eval: function(code) {
-		var result = prog(parseList(new Source(code))).toString();
+		var result = prog(parseList(new Source(code)));
 		A3.setVal(A2.getVal()); A2.setVal(A1.getVal()); A1.setVal(result);
-		return result;
+		return result.toString();
 	}
 }
 


### PR DESCRIPTION
This was a problem when `@` contained a number and you needed to do something like `(* 2 @)`.
